### PR TITLE
Skip installing templates and manifest when SDK, Ref, and Runtime pack versions cannot be obtained.

### DIFF
--- a/src/Elskom.Check.csproj
+++ b/src/Elskom.Check.csproj
@@ -12,7 +12,7 @@
     <LangVersion>latest</LangVersion>
     <PackageId>Elskom.Net.Check</PackageId>
     <Title>.NET Elskom Workload Check Tool</Title>
-    <Version>1.0.11</Version>
+    <Version>1.0.12</Version>
     <Authors>Els_kom org.</Authors>
     <Owners>Els_kom org.</Owners>
     <summary>A dotnet tool for installing/uninstalling and updating the Elskom workload.</summary>
@@ -20,7 +20,7 @@
       A dotnet tool for installing/uninstalling and updating the Elskom workload.
     </PackageDescription>
     <PackageReleaseNotes>
-       Fixed issue installing / updating the workload does not factor in manually installed runtime and reference pack updates.
+       Skip installing templates and manifest when SDK, Ref, and Runtime pack versions cannot be obtained.
     </PackageReleaseNotes>
     <Copyright>Copyright © 2021</Copyright>
     <PackageProjectUrl>https://github.com/Elskom/installer</PackageProjectUrl>

--- a/src/InstallCommand.cs
+++ b/src/InstallCommand.cs
@@ -69,20 +69,27 @@ public class InstallCommand : AsyncCommand<WorkloadSettings>
             Console.WriteLine($"Successfully installed workload package '{Constants.RuntimePackName}'.");
         }
 
-        var templatePackVersion = await DownloadPackageAsync(
-            Constants.TemplatePackName).ConfigureAwait(false);
-        if (!templatePackVersion.Equals("already installed"))
+        // avoid installing the templates and the workload manifest if sdkPackVersion, refPackVersion,
+        // and runtimePackVersion is null or empty.
+        if (!string.IsNullOrEmpty(sdkPackVersion)
+            && !string.IsNullOrEmpty(refPackVersion)
+            && !string.IsNullOrEmpty(runtimePackVersion))
         {
-            Console.WriteLine($"Successfully installed workload package '{Constants.TemplatePackName}'.");
-        }
+            var templatePackVersion = await DownloadPackageAsync(
+                Constants.TemplatePackName).ConfigureAwait(false);
+            if (!templatePackVersion.Equals("already installed"))
+            {
+                Console.WriteLine($"Successfully installed workload package '{Constants.TemplatePackName}'.");
+            }
 
-        InstallManifest(settings.SdkVersion!, new Dictionary<string, string>
-        {
-            { Constants.SdkPackName, sdkPackVersion },
-            { Constants.RefPackName, refPackVersion },
-            { Constants.RuntimePackName, runtimePackVersion },
-            { Constants.TemplatePackName, templatePackVersion },
-        });
+            InstallManifest(settings.SdkVersion!, new Dictionary<string, string>
+            {
+                { Constants.SdkPackName, sdkPackVersion },
+                { Constants.RefPackName, refPackVersion },
+                { Constants.RuntimePackName, runtimePackVersion },
+                { Constants.TemplatePackName, templatePackVersion },
+            });
+        }
         return 0;
     }
 


### PR DESCRIPTION
This should fix a bug where when it can be obtained it would generate an error saying to run "Update" instead.

# Checklist

- [x] I have read the Code of Conduct and the Contributing files before opening this issue.
- [x] I have verified the issue this pull request fixes or feature this pull request implements is to the current release.
- [x] I am using the latest stable release with the above code fix or the current main branch if code changes are present (prerelease code changes).
- [x] I have debugged and tested my changes before submitting this issue and that everything should just work.

## Describe the issue this fixes / feature this adds

<!-- A brief description of what this fixes or what this adds should be here. -->
